### PR TITLE
Add examples to test the `modules.yml` config file

### DIFF
--- a/custom_package/__init__.py
+++ b/custom_package/__init__.py
@@ -1,0 +1,6 @@
+from custom_package.test import some_string, iff
+
+__all__ = [
+    some_string.__name__,
+    iff.__name__,
+]

--- a/custom_package/test.py
+++ b/custom_package/test.py
@@ -1,0 +1,7 @@
+
+def some_string() -> str:
+    return "some string"
+
+
+def iff(condition: bool, if_true: str, if_false: str = "") -> str:
+    return if_true if condition else if_false

--- a/dbt-refresh.sh
+++ b/dbt-refresh.sh
@@ -8,3 +8,7 @@ dbt build --full-refresh
 
 dbt docs generate
 dbt docs serve
+
+
+# dbt run --select tag:module-test
+# dbt test --select tag:module-test

--- a/modules.yml
+++ b/modules.yml
@@ -1,0 +1,21 @@
+---
+modules:
+  # Standard library modules
+  - package: math
+    exports: [e, inf, nan, pi, tau]
+  - package: textwrap
+    exports:
+      - dedent
+      - indent
+
+  # Third-Party Packages
+  - package: requests
+    exports:
+      - codes
+
+  # Internal packages
+  - package: custom_package
+    location: "C:/Users/bill/Repos/bilbottom/billiam-database/"
+    exports:
+      - some_string
+      - iff

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,8 @@
 dbt-core==1.5.0
 dbt-duckdb==1.5.0
 duckdb==0.7.1
+
+pyyaml==6.0.1
+requests==2.31.0
+
+# pip install -e C:\Users\bill\Repos\third-parties\dbt-core\core

--- a/src/models/module_test_model.sql
+++ b/src/models/module_test_model.sql
@@ -1,0 +1,21 @@
+{{ config(
+    materialized="table",
+    tags=["module-test"]
+) }}
+
+SELECT
+    /* Standard Lib - math */
+    '{{ modules.math.e }}' AS e,
+    '{{ modules.math.inf }}' AS inf,
+    '{{ modules.math.nan }}' AS nan,
+    '{{ modules.math.pi }}' AS pi,
+    '{{ modules.math.tau }}' AS tau,
+
+    /* Third-Party Lib - requests */
+    '{{ modules.requests.codes.ok }}' AS ok,
+    '{{ modules.requests.codes.created }}' AS created,
+    '{{ modules.requests.codes.accepted }}' AS accepted,
+
+    /* Internal Lib - custom_package */
+    '{{ modules.custom_package.some_string() }}' AS some_string,
+    '{{ modules.custom_package.iff( is_incremental(), "do incremental thing", "do full refresh thing" ) }}' AS load_thing

--- a/src/tests/module-test.sql
+++ b/src/tests/module-test.sql
@@ -1,0 +1,20 @@
+{{ config(
+    tags=["module-test"]
+) }}
+
+SELECT
+    /* Standard Lib - math */
+    '{{ modules.math.e }}' AS e,
+    '{{ modules.math.inf }}' AS inf,
+    '{{ modules.math.nan }}' AS nan,
+    '{{ modules.math.pi }}' AS pi,
+    '{{ modules.math.tau }}' AS tau,
+
+    /* Third-Party Lib - requests */
+    '{{ modules.requests.codes.ok }}' AS ok,
+    '{{ modules.requests.codes.created }}' AS created,
+    '{{ modules.requests.codes.accepted }}' AS accepted,
+
+    /* Internal Lib - custom_package */
+    '{{ modules.custom_package.some_string() }}' AS some_string,
+    '{{ modules.custom_package.iff( is_incremental(), "do incremental thing", "do full refresh thing" ) }}' AS load_thing


### PR DESCRIPTION
This illustrates the usage of a customised [dbt-core](https://github.com/dbt-labs/dbt-core) fork, available at:
 - https://github.com/Bilbottom/dbt-core/tree/add-module-imports

---

The images below are the compiled SQL from the `--debug` output of a `run` and `test`, respectively

Model output:
![image](https://github.com/Bilbottom/billiam-database/assets/25640332/ddcce99e-698a-4b89-a2b3-a4227ba0a329)

Test output:
![image](https://github.com/Bilbottom/billiam-database/assets/25640332/ea49caa4-a168-4f8e-8d29-dd74af6d8b68)
