### PR TITLE
Remove pre-commit from the `run-tests.yaml` GitHub action

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -25,7 +25,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install -r requirements-dev.txt
 
       - name: Create mock database 🤡
         run: python -c "import duckdb; con = duckdb.connect('$GITHUB_WORKSPACE/src/billiam.duckdb'); con.close()"
@@ -38,9 +37,6 @@ jobs:
 
       - name: Parse dbt 🗃️
         run: dbt parse --profiles-dir .
-
-      - name: Run pre-commit 🌿
-        uses: pre-commit/action@v3.0.0
 
       - name: Run dbt unit tests 🧪
         run: dbt test --select tag:unit-test --profiles-dir .


### PR DESCRIPTION
The pre-commit checks are now handled by [pre-commit.ci](https://results.pre-commit.ci/)