### PR TITLE
Upgrade Metabase driver

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,9 +12,8 @@ services:
         source: ./dockerfiles/metaduck-data
         target: /metabase-data/
       - type: bind
-        source: ./billiam_database/
-        target: /billiam/
-    # http://localhost:3000/
-    ports: ["3000:3000"]
+        source: ./billiam_database/billiam.duckdb
+        target: /billiam.duckdb
+    ports: ["3000:3000"] # http://localhost:3000/
     environment:
       MB_DB_FILE: metabase-data/metabase.db

--- a/dockerfiles/metaduck.Dockerfile
+++ b/dockerfiles/metaduck.Dockerfile
@@ -3,8 +3,8 @@ FROM openjdk:19-buster
 
 ENV MB_PLUGINS_DIR=/home/plugins/
 
-ADD https://downloads.metabase.com/v0.47.4/metabase.jar /home/
-ADD https://github.com/AlexR2D2/metabase_duckdb_driver/releases/download/0.2.3/duckdb.metabase-driver.jar /home/plugins/
+ADD https://downloads.metabase.com/v0.52.4/metabase.jar /home
+ADD https://github.com/MotherDuck-Open-Source/metabase_duckdb_driver/releases/download/0.2.12/duckdb.metabase-driver.jar /home/plugins/
 
 RUN chmod 744 /home/plugins/duckdb.metabase-driver.jar
 


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update the Metabase Docker image to use a bind mount for the billiam.duckdb file instead of a directory mount.